### PR TITLE
ip: add rfc7343 ORCHID v2 addresses

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1131,6 +1131,24 @@ binet.isRFC4843 = function isRFC4843(raw) {
 };
 
 /**
+ * Test whether the ip is RFC 7343.
+ * @param {Buffer} raw
+ * @returns {Boolean}
+ */
+
+binet.isRFC7343 = function isRFC7343(raw) {
+  assert(Buffer.isBuffer(raw));
+  assert(raw.length === 16);
+
+  if (raw[0] === 0x20 && raw[1] === 0x01
+      && raw[2] === 0x00 && (raw[3] & 0xf0) === 0x20) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
  * Test whether the ip is local.
  * @param {Buffer} raw
  * @returns {Boolean}
@@ -1220,6 +1238,9 @@ binet.isRoutable = function isRoutable(raw) {
     return false;
 
   if (binet.isRFC4843(raw))
+    return false;
+
+  if (binet.isRFC7343(raw))
     return false;
 
   if (binet.isLocal(raw))

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -7,6 +7,14 @@
  * Parts of this software are based on node-ip.
  * https://github.com/indutny/node-ip
  * Copyright (c) 2012, Fedor Indutny (MIT License).
+ *
+ * Parts of this software are based on bitcoin/bitcoin:
+ * Copyright (c) 2009-2019, The Bitcoin Core Developers (MIT License).
+ * Copyright (c) 2009-2019, The Bitcoin Developers (MIT License).
+ * https://github.com/bitcoin/bitcoin
+ *
+ * Resources:
+ *   https://github.com/bitcoin/bitcoin/blob/master/src/netaddress.cpp
  */
 
 /* eslint no-unreachable: "off" */
@@ -1130,11 +1138,13 @@ binet.isRFC4843 = function isRFC4843(raw) {
 
 binet.isLocal = function isLocal(raw) {
   if (binet.isIPv4(raw)) {
+    // IPv4 loopback (127.0.0.0/8 or 0.0.0.0/8)
     if (raw[12] === 127 || raw[12] === 0)
       return true;
     return false;
   }
 
+  // IPv6 loopback (::1/128)
   if (binet.isEqual(raw, LOCAL_IP))
     return true;
 

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1130,7 +1130,7 @@ binet.isRFC4843 = function isRFC4843(raw) {
 
 binet.isLocal = function isLocal(raw) {
   if (binet.isIPv4(raw)) {
-    if (raw[12] === 127 && raw[13] === 0)
+    if (raw[12] === 127 || raw[12] === 0)
       return true;
     return false;
   }

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1123,6 +1123,24 @@ binet.isRFC4843 = function isRFC4843(raw) {
 };
 
 /**
+ * Test whether the ip is RFC 7343.
+ * @param {Buffer} raw
+ * @returns {Boolean}
+ */
+
+binet.isRFC7343 = function isRFC7343(raw) {
+  assert(Buffer.isBuffer(raw));
+  assert(raw.length === 16);
+
+  if (raw[0] === 0x20 && raw[1] === 0x01
+      && raw[2] === 0x00 && (raw[3] & 0xf0) === 0x20) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
  * Test whether the ip is local.
  * @param {Buffer} raw
  * @returns {Boolean}
@@ -1210,6 +1228,9 @@ binet.isRoutable = function isRoutable(raw) {
     return false;
 
   if (binet.isRFC4843(raw))
+    return false;
+
+  if (binet.isRFC7343(raw))
     return false;
 
   if (binet.isLocal(raw))

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1132,6 +1132,8 @@ binet.isRFC4843 = function isRFC4843(raw) {
 
 /**
  * Test whether the ip is RFC 7343.
+ * IPv6 ORCHIDv2 (2001:20::/28)
+ * https://tools.ietf.org/html/rfc7343
  * @param {Buffer} raw
  * @returns {Boolean}
  */

--- a/test/binet-test.js
+++ b/test/binet-test.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2017-2018, Christopher Jeffrey (MIT License).
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * Copyright (c) 2019, Sean Kilgarriff (MIT License).
+ *
+ * Parts of this software are based on bitcoin/bitcoin:
+ * Copyright (c) 2009-2019, The Bitcoin Core Developers (MIT License).
+ * Copyright (c) 2009-2019, The Bitcoin Developers (MIT License).
+ * https://github.com/bitcoin/bitcoin
+ *
+ * Resources:
+ *   https://github.com/bitcoin/bitcoin/blob/master/src/test/netbase_tests.cpp
+ */
+
 /* eslint-env mocha */
 /* eslint prefer-arrow-callback: "off" */
 
@@ -51,5 +65,38 @@ describe('binet', function() {
 
     assert.strictEqual(binet.encode(raw4), ip4);
     assert.strictEqual(binet.encode(raw6), ip6);
+  });
+
+  it('should return the correct property', () => {
+    assert(binet.isIPv4(binet.decode('127.0.0.1')));
+    assert(binet.isIPv4(binet.decode('::FFFF:192.168.1.1')));
+    assert(binet.isIPv6(binet.decode('::1')));
+    assert(binet.isRFC1918(binet.decode('10.0.0.1')));
+    assert(binet.isRFC1918(binet.decode('192.168.1.1')));
+    assert(binet.isRFC1918(binet.decode('172.31.255.255')));
+    assert(binet.isRFC3849(binet.decode('2001:0DB8::')));
+    assert(binet.isRFC3927(binet.decode('169.254.1.1')));
+    assert(binet.isRFC3964(binet.decode('2002::1')));
+    assert(binet.isRFC4193(binet.decode('FC00::')));
+    assert(binet.isRFC4380(binet.decode('2001::2')));
+    assert(binet.isRFC4843(binet.decode('2001:10::')));
+    assert(binet.isRFC4862(binet.decode('FE80::')));
+    assert(binet.isRFC6052(binet.decode('64:FF9B::')));
+    assert(
+      binet.isOnion(binet.decode('FD87:D87E:EB43:edb1:8e4:3588:e546:35ca'))
+    );
+
+    // isLocal should return true for:
+    // - IPv4 loopback (127.0.0.0/8 or 0.0.0.0/8)
+    // - IPv6 loopback (::1/128)
+    assert(binet.isLocal(binet.decode('127.0.0.1')));
+    assert(binet.isLocal(binet.decode('::1')));
+    assert(binet.isLocal(binet.decode('0.1.0.0')));
+    assert(!binet.isLocal(binet.decode('1.0.0.0')));
+    assert(!binet.isLocal(binet.decode('::2')));
+
+    assert(binet.isRoutable(binet.decode('8.8.8.8')));
+    assert(binet.isRoutable(binet.decode('2001::1')));
+    assert(binet.isValid(binet.decode('127.0.0.1')));
   });
 });

--- a/test/binet-test.js
+++ b/test/binet-test.js
@@ -95,6 +95,15 @@ describe('binet', function() {
     assert(!binet.isLocal(binet.decode('1.0.0.0')));
     assert(!binet.isLocal(binet.decode('::2')));
 
+    // isRFC7343 should return true for:
+    // - IPv6 ORCHIDv2 (2001:20::/28)
+    assert(binet.isRFC7343(binet.decode('2001:20::')));
+    assert(
+      binet.isRFC7343(binet.decode('2001:2f:ffff:ffff:ffff:ffff:ffff:ffff'))
+    );
+    assert(!binet.isRFC7343(binet.decode('2002:20::')));
+    assert(!binet.isRFC7343(binet.decode('0.0.0.0')));
+
     assert(binet.isRoutable(binet.decode('8.8.8.8')));
     assert(binet.isRoutable(binet.decode('2001::1')));
     assert(binet.isValid(binet.decode('127.0.0.1')));


### PR DESCRIPTION
ORCHID v1 addresses were deprecated because they lacked "a mechanism for cryptographic algorithm agility". This commit simply adds in a check for the new address format
defined in RFC 7343.