### PR TITLE
ip: return network.none for unroutable IPs

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1226,7 +1226,7 @@ binet.isRoutable = function isRoutable(raw) {
  */
 
 binet.getNetwork = function getNetwork(raw) {
-  if (!binet.isRoutable())
+  if (!binet.isRoutable(raw))
     return networks.NONE;
 
   if (binet.isIPv4(raw))

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1226,6 +1226,9 @@ binet.isRoutable = function isRoutable(raw) {
  */
 
 binet.getNetwork = function getNetwork(raw) {
+  if (!binet.isRoutable())
+    return networks.NONE;
+
   if (binet.isIPv4(raw))
     return networks.INET4;
 


### PR DESCRIPTION
Currently the getNetwork function will return INET6 (it's default return
value) for a non-routable IP address, and INET4 for some addresses that also technically are IPv4, but still unroutable. Switching this behavior mimics Bitcoin Core in that it returns a network value of 0 for an unroutable
IP.

Source: https://github.com/bitcoin/bitcoin/blob/master/src/netaddress.cpp#L315